### PR TITLE
🐛 Linear gradient fill not working in linux

### DIFF
--- a/src/utils/getColor.ts
+++ b/src/utils/getColor.ts
@@ -1,8 +1,8 @@
 const getColor = (color: string) => {
   return color.includes('linear-gradient') ? {
     'background': color,
-    'backgroundClip': 'text',
-    'WebkitTextFillColor': 'transparent'
+    'WebkitBackgroundClip' : 'text',
+    'WebkitTextFillColor': 'transparent',
   } : { color }
 }
 


### PR DESCRIPTION
For linear gradients, style add -webit-background-clip to text.